### PR TITLE
fix: Broken link in introduction index

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -10,5 +10,5 @@ Get started with our [Hello Nostr tutorial](/tutorials/hello-nostr) and check ba
 
 ### [Hello Nostr](https://github.com/NostrDevKit/hello-nostr)
 
-The sample serves as a simple starting point and implements the program described in the [Hello Nostr tutorial](nostr)
+The sample serves as a simple starting point and implements the program described in the [Hello Nostr tutorial](/tutorials/hello-nostr)
 


### PR DESCRIPTION
The second link in the introduction index leads to a 404 page. This patch uses the URL from the first (working) link in the page.